### PR TITLE
added missing comma

### DIFF
--- a/custom_components/pax_ble/translations/sv.json
+++ b/custom_components/pax_ble/translations/sv.json
@@ -14,7 +14,7 @@
 			}
 		},
 		"error": {
-			"cannot_connect": "Anslutning misslyckades"
+			"cannot_connect": "Anslutning misslyckades",
 			"wrong_pin": "Fel PIN"
 		},
 		"abort": {


### PR DESCRIPTION
a comma was missing in the translation file, which generated the following error:
```
2023-02-23 10:05:23.578 ERROR (SyncWorker_3) [homeassistant.util.json] Could not parse JSON content: /config/custom_components/pax_ble/translations/sv.json
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/util/json.py", line 39, in load_json
    return orjson.loads(fdesc.read())  # type: ignore[no-any-return]
orjson.JSONDecodeError: unexpected character: line 18 column 4 (char 369)
2023-02-23 10:05:23.579 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140046743605920] Error handling message: unexpected character: line 18 column 4 (char 369) (unknown_error) from 10.5.50.70 (Mozilla/5.0 (Linux; Android 8.0.0; AGS2-W09 Build/HUAWEIAGS2-W09; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/110.0.5481.65 Safari/537.36 Home Assistant/2022.11.0-2948 (Android 8.0.0; AGS2-W09))
2023-02-23 10:05:23.589 ERROR (SyncWorker_0) [homeassistant.util.json] Could not parse JSON content: /config/custom_components/pax_ble/translations/sv.json
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/util/json.py", line 39, in load_json
    return orjson.loads(fdesc.read())  # type: ignore[no-any-return]
orjson.JSONDecodeError: unexpected character: line 18 column 4 (char 369)
2023-02-23 10:05:23.590 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140046743605920] Error handling message: unexpected character: line 18 column 4 (char 369) (unknown_error) from 10.5.50.70 (Mozilla/5.0 (Linux; Android 8.0.0; AGS2-W09 Build/HUAWEIAGS2-W09; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/110.0.5481.65 Safari/537.36 Home Assistant/2022.11.0-2948 (Android 8.0.0; AGS2-W09))
2023-02-23 10:05:23.597 ERROR (SyncWorker_7) [homeassistant.util.json] Could not parse JSON content: /config/custom_components/pax_ble/translations/sv.json
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/util/json.py", line 39, in load_json
    return orjson.loads(fdesc.read())  # type: ignore[no-any-return]
orjson.JSONDecodeError: unexpected character: line 18 column 4 (char 369)
2023-02-23 10:05:23.600 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140046743605920] Error handling message: unexpected character: line 18 column 4 (char 369) (unknown_error) from 10.5.50.70 (Mozilla/5.0 (Linux; Android 8.0.0; AGS2-W09 Build/HUAWEIAGS2-W09; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/110.0.5481.65 Safari/537.36 Home Assistant/2022.11.0-2948 (Android 8.0.0; AGS2-W09))

```