### PR TITLE
Lower minimum allowed Fan RPM.

### DIFF
--- a/custom_components/pax_ble/number.py
+++ b/custom_components/pax_ble/number.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 OptionsTuple = namedtuple('options', ['min_value', 'max_value', 'step'])
 OPTIONS = {}
-OPTIONS["fanspeed"] = OptionsTuple(400, 2400, 25)
+OPTIONS["fanspeed"] = OptionsTuple(500, 2400, 25)
 OPTIONS["temperature"] = OptionsTuple(15, 30, 1)
 OPTIONS["boostmodesec"] = OptionsTuple(60, 900, 1)
 OPTIONS["boostmodespeed"] = OptionsTuple(1000, 2400, 25)

--- a/custom_components/pax_ble/number.py
+++ b/custom_components/pax_ble/number.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 OptionsTuple = namedtuple('options', ['min_value', 'max_value', 'step'])
 OPTIONS = {}
-OPTIONS["fanspeed"] = OptionsTuple(800, 2400, 25)
+OPTIONS["fanspeed"] = OptionsTuple(400, 2400, 25)
 OPTIONS["temperature"] = OptionsTuple(15, 30, 1)
 OPTIONS["boostmodesec"] = OptionsTuple(60, 900, 1)
 OPTIONS["boostmodespeed"] = OptionsTuple(1000, 2400, 25)


### PR DESCRIPTION
Lower the minimume allowed rpm. 
This keeps the motor running, but has less significant impact on the air-flow. 

This is needed when the fan is used for forced air move inside->out and no backstop is installed and fan can't/should not be turned off.