### PR TITLE
pax_ble: Improve BLE connection resilience

### DIFF
--- a/custom_components/pax_ble/__init__.py
+++ b/custom_components/pax_ble/__init__.py
@@ -107,7 +107,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Unloading Pax BLE entry!")
 
     # Make sure we are disconnected
-    for dev_id, coordinator in hass.data[DOMAIN][CONF_DEVICES].items():
+    devices = hass.data[DOMAIN].get(entry.entry_id, {}).get(CONF_DEVICES, {})
+    for dev_id, coordinator in devices.items():
         await coordinator.disconnect()
 
     # Unload entries

--- a/custom_components/pax_ble/coordinator_calima.py
+++ b/custom_components/pax_ble/coordinator_calima.py
@@ -23,7 +23,7 @@ class CalimaCoordinator(BaseCoordinator):
         _LOGGER.debug("Reading sensor data")
         try:
             # Make sure we are connected
-            if not await self._fan.connect():
+            if not await self._safe_connect():
                 raise Exception("Not connected!")
         except Exception as e:
             _LOGGER.warning("Error when fetching config data: %s", str(e))
@@ -58,7 +58,7 @@ class CalimaCoordinator(BaseCoordinator):
         _LOGGER.debug("Write_Data: %s", key)
         try:
             # Make sure we are connected
-            if not await self._fan.connect():
+            if not await self._safe_connect():
                 raise Exception("Not connected!")
         except Exception as e:
             _LOGGER.warning("Error when writing data: %s", str(e))
@@ -125,7 +125,7 @@ class CalimaCoordinator(BaseCoordinator):
     async def read_configdata(self, disconnect=False) -> bool:
         try:
             # Make sure we are connected
-            if not await self._fan.connect():
+            if not await self._safe_connect():
                 raise Exception("Not connected!")
         except Exception as e:
             _LOGGER.warning("Error when fetching config data: %s", str(e))

--- a/custom_components/pax_ble/coordinator_svensa.py
+++ b/custom_components/pax_ble/coordinator_svensa.py
@@ -22,7 +22,7 @@ class SvensaCoordinator(BaseCoordinator):
         _LOGGER.debug("Reading sensor data")
         try:
             # Make sure we are connected
-            if not await self._fan.connect():
+            if not await self._safe_connect():
                 raise Exception("Not connected!")
         except Exception as e:
             _LOGGER.warning("Error when fetching config data: %s", str(e))
@@ -58,7 +58,7 @@ class SvensaCoordinator(BaseCoordinator):
         _LOGGER.debug("Write_Data: %s", key)
         try:
             # Make sure we are connected
-            if not await self._fan.connect():
+            if not await self._safe_connect():
                 raise Exception("Not connected!")
         except Exception as e:
             _LOGGER.warning("Error when writing data: %s", str(e))
@@ -128,7 +128,7 @@ class SvensaCoordinator(BaseCoordinator):
     async def read_configdata(self, disconnect=False) -> bool:
         try:
             # Make sure we are connected
-            if not await self._fan.connect():
+            if not await self._safe_connect():
                 raise Exception("Not connected!")
         except Exception as e:
             _LOGGER.warning("Error when fetching config data: %s", str(e))


### PR DESCRIPTION
Reuse a single BleakClient instance in BaseDevice.connect, instead of recreating a new client on every connect call.

Introduce BaseDevice._with_disconnect_on_error to wrap all GATT read/write operations. On any exception, the client will be cleanly disconnected to prevent stale sessions.

Enhance BaseCoordinator._safe_connect with a fixed five‑attempt exponential backoff (1s, 2s, 4s, 8s), removing the previous retry parameters and making retry logic consistent across all coordinators.

Fixes #62.