### PR TITLE
Fix for Home Assistant warning for not using bleak-retry-connector

### DIFF
--- a/custom_components/pax_ble/manifest.json
+++ b/custom_components/pax_ble/manifest.json
@@ -11,6 +11,6 @@
 	"iot_class": "local_polling",
 	"issue_tracker": "https://github.com/eriknn/ha-pax/issues",
 	"loggers": ["custom_components.pax_ble"],
-	"requirements": [],
+	"requirements": ["bleak-retry-connector>=3.7.0"],
 	"version": "1.1.15"
 }


### PR DESCRIPTION
This might fix the warning message home assistant gives for not using bleak-retry-connector. 

Logger: habluetooth.wrappers
Source: custom_components/pax_ble/devices/base_device.py:70
integration: Pax Bluetooth (documentation, issues)
First occurred: 08:36:33 (4 occurrences)
Last logged: 08:37:10

58:2B:DB:35:17:62: BleakClient.connect() called without bleak-retry-connector. For reliable connection establishment, use bleak_retry_connector.establish_connection(). See https://github.com/Bluetooth-Devices/bleak-retry-connector