### PR TITLE
Improved support for Pax Levante

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you've got other fans of the same'ish type, just give it a go and let me know
 
 ## Add device
 
-The integration supports discovery of devices, but only for Calima (until someone tells me how I can add multiple device-types in manifest "local_name", or if there's another way...)
+The integration supports discovery of devices for Calima and Levante.
 If discovery doesn't work you may try to add it manually through the integration configuration.
 If you have issues connecting, try cycling power on the device. It seems that the Bluetooth interface easily hangs if it's messed around with a bit.
 
@@ -28,7 +28,7 @@ For Svensa-specific instructions, see [here](svensa.md).
 A valid PIN code is required to be able to control the fan. You can add the fan without PIN, but then you'll only be able to read values.
 * For Calima/Svara you just enter the decimal value printed on the fan motor (remove from base)
 * For Svensa, the PIN is not written on the device, but should be requested from it. See [instructions for Svensa](svensa.md).
-* For Levante 50, select Calima as model but request the PIN using the steps outlined for Svensa. Enter pairing mode by powercycling the fan using the switch on the side.
+* For Levante 50, enter pairing mode by powercycling the fan using the switch on the side just before adding the device. The PIN should be discovered automatically. If this fails, see instructions for Svensa.
 
 ## Sensor data
 

--- a/custom_components/pax_ble/config_flow.py
+++ b/custom_components/pax_ble/config_flow.py
@@ -97,6 +97,8 @@ class PaxConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by bluetooth discovery."""
         _LOGGER.debug("Discovered device: %s", discovery_info.address)
         self.device_data[CONF_MAC] = dr.format_mac(discovery_info.address)
+        self.device_data[CONF_NAME] = discovery_info.name
+        self.context["title_placeholders"] = {"name": discovery_info.name}
 
         """Abort if we already have a discovery in process for this device"""
         await self.async_set_unique_id(self.device_data[CONF_MAC])

--- a/custom_components/pax_ble/const.py
+++ b/custom_components/pax_ble/const.py
@@ -34,5 +34,6 @@ DEFAULT_SCAN_INTERVAL_FAST: int = 5  # Seconds
 # Device models
 class DeviceModel(str, Enum):
     CALIMA = "Calima"
+    LEVANTE = "Levante"
     SVARA = "Svara"
     SVENSA = "Svensa"

--- a/custom_components/pax_ble/helpers.py
+++ b/custom_components/pax_ble/helpers.py
@@ -22,7 +22,7 @@ def getCoordinator(hass, device_data, dev):
     # Set up coordinator
     coordinator = None
     match DeviceModel(model):
-        case DeviceModel.CALIMA | DeviceModel.SVARA:
+        case DeviceModel.CALIMA | DeviceModel.SVARA | DeviceModel.LEVANTE:
             coordinator = CalimaCoordinator(
                 hass, dev, model, mac, pin, scan_interval, scan_interval_fast
             )

--- a/custom_components/pax_ble/manifest.json
+++ b/custom_components/pax_ble/manifest.json
@@ -2,7 +2,8 @@
 	"domain": "pax_ble",
 	"name": "Pax Bluetooth",
 	"bluetooth": [
-		{"local_name": "PAX Calima"}
+		{"local_name": "PAX Calima"},
+		{"local_name": "Pax Levante"}
 	],
 	"codeowners": ["@eriknn"],
 	"config_flow": true,

--- a/custom_components/pax_ble/number.py
+++ b/custom_components/pax_ble/number.py
@@ -146,7 +146,11 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
         # Device specific entities
         match coordinator._model:
-            case DeviceModel.CALIMA.value | DeviceModel.SVARA.value:
+            case (
+                DeviceModel.CALIMA.value
+                | DeviceModel.SVARA.value
+                | DeviceModel.LEVANTE.value
+            ):
                 for paxentity in CALIMA_ENTITIES:
                     ha_entities.append(PaxCalimaNumberEntity(coordinator, paxentity))
             case DeviceModel.SVENSA.value:

--- a/custom_components/pax_ble/select.py
+++ b/custom_components/pax_ble/select.py
@@ -155,6 +155,9 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             case DeviceModel.CALIMA.value:
                 for paxentity in CALIMA_ENTITIES:
                     ha_entities.append(PaxCalimaSelectEntity(coordinator, paxentity))
+            case DeviceModel.LEVANTE.value:
+                for paxentity in CALIMA_ENTITIES:
+                    ha_entities.append(PaxCalimaSelectEntity(coordinator, paxentity))
             case DeviceModel.SVENSA.value:
                 for paxentity in SVENSA_ENTITIES:
                     ha_entities.append(PaxCalimaSelectEntity(coordinator, paxentity))

--- a/custom_components/pax_ble/switch.py
+++ b/custom_components/pax_ble/switch.py
@@ -73,7 +73,11 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
         # Device specific entities
         match coordinator._model:
-            case DeviceModel.CALIMA.value | DeviceModel.SVARA.value:
+            case (
+                DeviceModel.CALIMA.value
+                | DeviceModel.SVARA.value
+                | DeviceModel.LEVANTE.value
+            ):
                 for paxentity in CALIMA_ENTITIES:
                     ha_entities.append(PaxCalimaSwitchEntity(coordinator, paxentity))
             case DeviceModel.SVENSA.value:

--- a/custom_components/pax_ble/time.py
+++ b/custom_components/pax_ble/time.py
@@ -45,7 +45,11 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
         # Device specific entities
         match coordinator._model:
-            case DeviceModel.CALIMA.value | DeviceModel.SVARA.value:
+            case (
+                DeviceModel.CALIMA.value
+                | DeviceModel.SVARA.value
+                | DeviceModel.LEVANTE.value
+            ):
                 for paxentity in CALIMA_ENTITIES:
                     ha_entities.append(PaxCalimaTimeEntity(coordinator, paxentity))
             case DeviceModel.SVENSA.value:


### PR DESCRIPTION
Improves support for Pax Levante fans:
  - Add bluetooth auto-discovery for Pax Levante, alongside PAX Calima
  - Auto-discover the Levante PIN during setup if the fan was recently power cycled
  - Show the discovered device name in the Bluetooth discovery card 
  
  
<img width="631" height="257" alt="image" src="https://github.com/user-attachments/assets/f52ab6ac-e250-4d2c-a390-cb29dc01c710" />

  
The code has been tested in an environment with a mixture of Calima and Levante fans. 

Both bluetooth and PIN auto-discovery are probably generalizable to Svensa fans, but as I don't have any of those to test on, I limited added auto-discovery support to Levante for now.

Note that some of this code is authored with Claude Code but I have reviewed every line manually. 