### PR TITLE
pax_ble: Fix Calima clock and grouped writes

### DIFF
--- a/custom_components/pax_ble/coordinator_calima.py
+++ b/custom_components/pax_ble/coordinator_calima.py
@@ -3,6 +3,8 @@ import logging
 
 from typing import Optional
 
+from homeassistant.util import dt as dt_util
+
 from .coordinator import BaseCoordinator
 from .devices.calima import Calima
 
@@ -26,6 +28,7 @@ class CalimaCoordinator(BaseCoordinator):
 
         # Set up disconnect callback
         self._fan.set_disconnect_callback(self._on_device_disconnect)
+        self._last_clock_sync_check: Optional[dt.datetime] = None
 
     async def read_sensordata(self, disconnect=False) -> bool:
         _LOGGER.debug("Reading sensor data")
@@ -34,6 +37,8 @@ class CalimaCoordinator(BaseCoordinator):
             if not await self._safe_connect():
                 _LOGGER.debug("Cannot read sensor data: not connected to %s", self.devicename)
                 return False
+
+            await self._sync_clock_if_needed()
 
             FanState = await self._fan.getState()  # Sensors
             BoostMode = await self._fan.getBoostMode()  # Sensors?
@@ -62,6 +67,51 @@ class CalimaCoordinator(BaseCoordinator):
 
         except Exception as e:
             _LOGGER.debug("Error reading sensor data from %s: %s", self.devicename, str(e))
+            return False
+
+    async def _sync_clock_if_needed(self, force: bool = False) -> bool:
+        now = dt_util.now()
+        if (
+            not force
+            and self._last_clock_sync_check is not None
+            and now - self._last_clock_sync_check < dt.timedelta(minutes=10)
+        ):
+            return True
+
+        try:
+            fan_time = await self._fan.getTime()
+            current_seconds = now.hour * 3600 + now.minute * 60 + now.second
+            fan_seconds = fan_time.Hour * 3600 + fan_time.Minute * 60 + fan_time.Second
+            time_delta = abs(current_seconds - fan_seconds)
+            time_delta = min(time_delta, 86400 - time_delta)
+
+            if fan_time.DayOfWeek == now.isoweekday() and time_delta <= 120:
+                self._last_clock_sync_check = now
+                return True
+
+            await self._fan.authorize()
+            await self._fan.setTime(
+                now.isoweekday(),
+                now.hour,
+                now.minute,
+                now.second,
+            )
+            self._last_clock_sync_check = now
+            _LOGGER.info(
+                "Synced clock for %s from day=%s %02d:%02d:%02d to day=%s %02d:%02d:%02d",
+                self.devicename,
+                fan_time.DayOfWeek,
+                fan_time.Hour,
+                fan_time.Minute,
+                fan_time.Second,
+                now.isoweekday(),
+                now.hour,
+                now.minute,
+                now.second,
+            )
+            return True
+        except Exception as e:
+            _LOGGER.warning("Unable to sync clock for %s: %s", self.devicename, str(e))
             return False
 
     async def write_data(self, key) -> bool:

--- a/custom_components/pax_ble/coordinator_calima.py
+++ b/custom_components/pax_ble/coordinator_calima.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime as dt
 import logging
 
@@ -29,6 +30,11 @@ class CalimaCoordinator(BaseCoordinator):
         # Set up disconnect callback
         self._fan.set_disconnect_callback(self._on_device_disconnect)
         self._last_clock_sync_check: Optional[dt.datetime] = None
+        self._operation_lock = asyncio.Lock()
+
+    async def _async_update_data(self):
+        async with self._operation_lock:
+            return await super()._async_update_data()
 
     async def read_sensordata(self, disconnect=False) -> bool:
         _LOGGER.debug("Reading sensor data")
@@ -38,7 +44,11 @@ class CalimaCoordinator(BaseCoordinator):
                 _LOGGER.debug("Cannot read sensor data: not connected to %s", self.devicename)
                 return False
 
-            await self._sync_clock_if_needed()
+            if (
+                not await self._sync_clock_if_needed()
+                and not await self._safe_connect()
+            ):
+                return False
 
             FanState = await self._fan.getState()  # Sensors
             BoostMode = await self._fan.getBoostMode()  # Sensors?
@@ -80,14 +90,30 @@ class CalimaCoordinator(BaseCoordinator):
 
         try:
             fan_time = await self._fan.getTime()
-            current_seconds = now.hour * 3600 + now.minute * 60 + now.second
-            fan_seconds = fan_time.Hour * 3600 + fan_time.Minute * 60 + fan_time.Second
-            time_delta = abs(current_seconds - fan_seconds)
-            time_delta = min(time_delta, 86400 - time_delta)
+            current_seconds = (
+                (now.isoweekday() - 1) * 86400
+                + now.hour * 3600
+                + now.minute * 60
+                + now.second
+            )
+            if (
+                1 <= fan_time.DayOfWeek <= 7
+                and 0 <= fan_time.Hour <= 23
+                and 0 <= fan_time.Minute <= 59
+                and 0 <= fan_time.Second <= 59
+            ):
+                fan_seconds = (
+                    (fan_time.DayOfWeek - 1) * 86400
+                    + fan_time.Hour * 3600
+                    + fan_time.Minute * 60
+                    + fan_time.Second
+                )
+                time_delta = abs(current_seconds - fan_seconds)
+                time_delta = min(time_delta, 7 * 86400 - time_delta)
 
-            if fan_time.DayOfWeek == now.isoweekday() and time_delta <= 120:
-                self._last_clock_sync_check = now
-                return True
+                if time_delta <= 120:
+                    self._last_clock_sync_check = now
+                    return True
 
             await self._fan.authorize()
             await self._fan.setTime(
@@ -115,6 +141,11 @@ class CalimaCoordinator(BaseCoordinator):
             return False
 
     async def write_data(self, key) -> bool:
+        requested_value = self._state.get(key)
+        async with self._operation_lock:
+            return await self._write_data(key, requested_value)
+
+    async def _write_data(self, key, requested_value) -> bool:
         _LOGGER.debug("Write_Data: %s", key)
         try:
             # Make sure we are connected
@@ -122,8 +153,84 @@ class CalimaCoordinator(BaseCoordinator):
                 _LOGGER.debug("Cannot write data: not connected to %s", self.devicename)
                 return False
 
+            if (
+                not await self._sync_clock_if_needed()
+                and not await self._safe_connect()
+            ):
+                return False
+
             # Authorize
             await self._fan.authorize()
+            required_config_keys = {
+                "fanspeed_humidity": (
+                    "fanspeed_humidity",
+                    "fanspeed_light",
+                    "fanspeed_trickle",
+                ),
+                "fanspeed_light": (
+                    "fanspeed_humidity",
+                    "fanspeed_light",
+                    "fanspeed_trickle",
+                ),
+                "fanspeed_trickle": (
+                    "fanspeed_humidity",
+                    "fanspeed_light",
+                    "fanspeed_trickle",
+                ),
+                "lightsensorsettings_delayedstart": (
+                    "lightsensorsettings_delayedstart",
+                    "lightsensorsettings_runningtime",
+                ),
+                "lightsensorsettings_runningtime": (
+                    "lightsensorsettings_delayedstart",
+                    "lightsensorsettings_runningtime",
+                ),
+                "sensitivity_humidity": ("sensitivity_humidity", "sensitivity_light"),
+                "sensitivity_light": ("sensitivity_humidity", "sensitivity_light"),
+                "trickledays_weekdays": (
+                    "trickledays_weekdays",
+                    "trickledays_weekends",
+                ),
+                "trickledays_weekends": (
+                    "trickledays_weekdays",
+                    "trickledays_weekends",
+                ),
+                "silenthours_on": (
+                    "silenthours_on",
+                    "silenthours_starttime",
+                    "silenthours_endtime",
+                ),
+                "silenthours_starttime": (
+                    "silenthours_on",
+                    "silenthours_starttime",
+                    "silenthours_endtime",
+                ),
+                "silenthours_endtime": (
+                    "silenthours_on",
+                    "silenthours_starttime",
+                    "silenthours_endtime",
+                ),
+                "heatdistributorsettings_temperaturelimit": (
+                    "heatdistributorsettings_temperaturelimit",
+                    "heatdistributorsettings_fanspeedbelow",
+                    "heatdistributorsettings_fanspeedabove",
+                ),
+                "heatdistributorsettings_fanspeedbelow": (
+                    "heatdistributorsettings_temperaturelimit",
+                    "heatdistributorsettings_fanspeedbelow",
+                    "heatdistributorsettings_fanspeedabove",
+                ),
+                "heatdistributorsettings_fanspeedabove": (
+                    "heatdistributorsettings_temperaturelimit",
+                    "heatdistributorsettings_fanspeedbelow",
+                    "heatdistributorsettings_fanspeedabove",
+                ),
+            }
+
+            if dependencies := required_config_keys.get(key):
+                if not await self._ensure_config_keys(*dependencies):
+                    return False
+            self._state[key] = requested_value
 
             # Write data
             match key:
@@ -186,12 +293,84 @@ class CalimaCoordinator(BaseCoordinator):
         except Exception as e:
             _LOGGER.debug("Error writing data to %s: %s", self.devicename, str(e))
             return False
+        finally:
+            await self._fan.disconnect()
+
+    async def _ensure_config_keys(self, *keys: str) -> bool:
+        try:
+            match keys[0]:
+                case "fanspeed_humidity":
+                    settings = await self._fan.getFanSpeedSettings()
+                    self._state["fanspeed_humidity"] = settings.Humidity
+                    self._state["fanspeed_light"] = settings.Light
+                    self._state["fanspeed_trickle"] = settings.Trickle
+                case "lightsensorsettings_delayedstart":
+                    settings = await self._fan.getLightSensorSettings()
+                    self._state["lightsensorsettings_delayedstart"] = (
+                        settings.DelayedStart
+                    )
+                    self._state["lightsensorsettings_runningtime"] = (
+                        settings.RunningTime
+                    )
+                case "sensitivity_humidity":
+                    settings = await self._fan.getSensorsSensitivity()
+                    self._state["sensitivity_humidity"] = settings.Humidity
+                    self._state["sensitivity_light"] = settings.Light
+                case "trickledays_weekdays":
+                    settings = await self._fan.getTrickleDays()
+                    self._state["trickledays_weekdays"] = settings.Weekdays
+                    self._state["trickledays_weekends"] = settings.Weekends
+                case "silenthours_on":
+                    settings = await self._fan.getSilentHours()
+                    self._state["silenthours_on"] = settings.On
+                    self._state["silenthours_starttime"] = dt.time(
+                        settings.StartingHour, settings.StartingMinute
+                    )
+                    self._state["silenthours_endtime"] = dt.time(
+                        settings.EndingHour, settings.EndingMinute
+                    )
+                case "heatdistributorsettings_temperaturelimit":
+                    settings = await self._fan.getHeatDistributor()
+                    self._state["heatdistributorsettings_temperaturelimit"] = (
+                        settings.TemperatureLimit
+                    )
+                    self._state["heatdistributorsettings_fanspeedbelow"] = (
+                        settings.FanSpeedBelow
+                    )
+                    self._state["heatdistributorsettings_fanspeedabove"] = (
+                        settings.FanSpeedAbove
+                    )
+                case _:
+                    return False
+        except Exception as e:
+            _LOGGER.debug(
+                "Error refreshing config group for %s: %s",
+                self.devicename,
+                str(e),
+            )
+            return False
+
+        missing = [key for key in keys if self._state.get(key) is None]
+        if missing:
+            _LOGGER.warning(
+                "Missing config values for %s after refresh: %s",
+                self.devicename,
+                ", ".join(missing),
+            )
+            return False
+        return True
 
     async def read_configdata(self, disconnect=False) -> bool:
         try:
             # Make sure we are connected
             if not await self._safe_connect():
                 raise Exception("Not connected!")
+
+            if (
+                not await self._sync_clock_if_needed(force=True)
+                and not await self._safe_connect()
+            ):
+                raise Exception("Not connected after clock sync failure")
 
             AutomaticCycles = await self._fan.getAutomaticCycles()  # Configuration
             self._state["automatic_cycles"] = AutomaticCycles


### PR DESCRIPTION
## What

- Synchronise the Calima clock when it is wrong or stale.
- Recheck it at a bounded interval and during configuration reads.
- Refresh sibling settings before grouped BLE writes.
- Avoid writing missing sibling values back to the fan.
- Disconnect cleanly after write attempts.

## Why

Calima loses its date and time after power loss, breaking weekday and weekend behaviour. Its grouped configuration commands also require current sibling values, otherwise a single setting change can overwrite unrelated settings.

## Validation

- `python3 -m compileall -q custom_components/pax_ble`
- Live weekday schedule, clock, trickle, and grouped-write readback on both fans
