### PR TITLE
Fix missing entities after config-entry reload when adding devices

### DIFF
--- a/custom_components/pax_ble/__init__.py
+++ b/custom_components/pax_ble/__init__.py
@@ -76,8 +76,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Set up update listener
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
-    # Register services
-    hass.services.async_register(DOMAIN, "request_update", partial(service_request_update, hass))
+    # Register services (only once across all entries)
+    if not hass.services.has_service(DOMAIN, "request_update"):
+        hass.services.async_register(DOMAIN, "request_update", partial(service_request_update, hass))
 
     return True
 
@@ -96,14 +97,12 @@ async def service_request_update(hass, call: ServiceCall):
         _LOGGER.error("No device entry found for device ID %s", device_id)
         return
 
-    """Find the coordinator corresponding to the given device ID."""
-    coordinators = hass.data[DOMAIN].get(CONF_DEVICES, {})
-
-    # Iterate through all coordinators and check their device_id property
-    for coordinator in coordinators.values():
-        if getattr(coordinator, "device_id", None) == device_id:
-            await coordinator._async_update_data()
-            return
+    # Find the coordinator corresponding to the given device ID
+    for entry_data in hass.data.get(DOMAIN, {}).values():
+        for coordinator in entry_data.get(CONF_DEVICES, {}).values():
+            if coordinator.device_id == device_id:
+                await coordinator._async_update_data()
+                return
 
     _LOGGER.warning("No coordinator found for device ID %s", device_id)
 
@@ -135,6 +134,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Unload entries
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    # Clear per-entry state so a config-entry reload can forward platforms again
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
 
     return unload_ok
 


### PR DESCRIPTION
## Summary

- Clear per-entry `hass.data[DOMAIN]` state on successful unload so `forwarded` does not block platform setup after `async_reload()`
- Fix `request_update` service coordinator lookup (was reading a non-existent top-level `devices` key)
- Register `request_update` service only once (`has_service` guard)

Fixes adding a second (or subsequent) fan via the config flow without requiring a full HA core restart.

## Problem

`async_setup_entry()` skips `async_forward_entry_setups()` when `hass.data[DOMAIN][entry_id]["forwarded"]` is already set. That flag is set on first setup but never cleared in `async_unload_entry()`.

The add-device config flow ends with:

```python
await self.hass.config_entries.async_reload(self.config_entry.entry_id)
```

After reload, coordinators exist but entities are not created until a full core restart.

## Changes

### `async_unload_entry`

Pop `entry.entry_id` from `hass.data[DOMAIN]` after a successful platform unload.

### `service_request_update`

Iterate coordinators under each config entry:

```python
for entry_data in hass.data.get(DOMAIN, {}).values():
    for coordinator in entry_data.get(CONF_DEVICES, {}).values():
        ...
```

### `async_setup_entry`

Guard service registration with `hass.services.has_service(DOMAIN, "request_update")`.

## Test plan

- [ ] Fresh install, add one Svara/Calima fan → entities created
- [ ] Add second fan via integration configure flow → **both** fans have entities without core restart
- [ ] Reload integration from UI → entities remain for all devices
- [ ] Remove one device → remaining device still works
- [ ] (Optional) Call `pax_ble.request_update` with a device registry ID → coordinator refresh runs

Tested with:

- HA 2026.7.3
- 2× Vent-Axia Svara on one Pax BLE config entry

## Related

Closes #106
Relates to #42, #54, #91