### PR TITLE
Fix HA 2026.8 CONCENTRATION_PARTS_PER_MILLION deprecation

### DIFF
--- a/custom_components/pax_ble/sensor.py
+++ b/custom_components/pax_ble/sensor.py
@@ -5,11 +5,11 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.const import CONF_DEVICES
 from homeassistant.const import UnitOfVolumeFlowRate, UnitOfTemperature, UnitOfTime
+from homeassistant.const import UnitOfRatio
 from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
-    CONCENTRATION_PARTS_PER_MILLION,
 )
 
 from .const import DOMAIN, CONF_NAME
@@ -50,7 +50,7 @@ SVENSA_ENTITIES = [
     PaxEntity(
         "airquality",
         "Air Quality",
-        CONCENTRATION_PARTS_PER_MILLION,
+        UnitOfRatio.PARTS_PER_MILLION,
         SensorDeviceClass.CO2,
         None,
         None,


### PR DESCRIPTION
## Summary
- Replace deprecated `CONCENTRATION_PARTS_PER_MILLION` with `UnitOfRatio.PARTS_PER_MILLION` for Svensa air quality sensor units.
- Seen on HA 2026.8.0: The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from pax_ble (removed in HA Core 2027.8).

## Test plan
- [x] Confirmed warning on HA 2026.8.0 with Vent-Axia Svara before this change
- [ ] Install this branch; confirm warning gone from core logs