### PR TITLE
Fix connection validation zombie and false Device Name failures

### DIFF
--- a/custom_components/pax_ble/devices/base_device.py
+++ b/custom_components/pax_ble/devices/base_device.py
@@ -56,18 +56,43 @@ class BaseDevice:
         """Set callback to be called when device disconnects unexpectedly."""
         self._disconnect_callback = callback
 
-    def _handle_disconnect(self, _client):
+    def _handle_disconnect(self, client):
         """Handle unexpected disconnection.
 
         Only logs the disconnection for debugging purposes.
         Reconnection is handled lazily on the next poll cycle.
         """
         _LOGGER.debug("Device %s disconnected, will reconnect on next poll", self._mac)
-        self._client = None
+        # Only clear if this callback is for the client we still own - a late
+        # callback for an old ACL must not orphan a newer connection (#101).
+        if self._client is client:
+            self._client = None
 
     async def authorize(self):
         await self.setAuth(self._pin)
 
+    def _take_client(self):
+        """Atomically clear and return the current client. Caller holds _connect_lock."""
+        client = self._client
+        self._client = None
+        return client
+
+    async def _disconnect_client(self, client) -> None:
+        """Await Bleak disconnect for a client already removed from the slot."""
+        if client is None:
+            return
+        try:
+            await client.disconnect()
+        except Exception as e:
+            _LOGGER.warning("Error disconnecting %s: %s", self._mac, e)
+
+    def _has_sensor_characteristic(self, sensor_uuid: str) -> bool:
+        if not self._client:
+            return False
+        try:
+            return self._client.services.get_characteristic(sensor_uuid) is not None
+        except Exception:
+            return False
 
     async def connect(
         self, timeout: int = 45, *, use_services_cache: bool = True
@@ -78,8 +103,7 @@ class BaseDevice:
 
         async with self._connect_lock:
             if self._client and self._client.is_connected:
-                # Already connected still needs a usable GATT map for polling.
-                if self._client.services.get_characteristic(sensor_uuid) is not None:
+                if self._has_sensor_characteristic(sensor_uuid):
                     return True
                 _LOGGER.debug(
                     "Already connected to %s but SENSOR_DATA missing; reconnecting",
@@ -89,19 +113,26 @@ class BaseDevice:
                     await self._client.clear_cache()
                 except Exception:
                     pass
-                try:
-                    await self._client.disconnect()
-                except Exception:
-                    pass
-                self._client = None
+                stale = self._take_client()
+                cache_attempts = (False,)
             elif self._client is not None:
-                try:
-                    await self._client.disconnect()
-                except Exception:
-                    pass
-                self._client = None
+                stale = self._take_client()
+            else:
+                stale = None
 
-            for use_cache in cache_attempts:
+        await self._disconnect_client(stale)
+
+        for use_cache in cache_attempts:
+            to_close = []
+            success = False
+            retry_uncached = False
+            async with self._connect_lock:
+                if self._client and self._client.is_connected:
+                    if self._has_sensor_characteristic(sensor_uuid):
+                        return True
+                if self._client is not None:
+                    to_close.append(self._take_client())
+
                 try:
                     device = bluetooth.async_ble_device_from_address(
                         self._hass, self._mac.upper()
@@ -125,59 +156,54 @@ class BaseDevice:
                         timeout=timeout,
                     )
 
-                    if self._client.services.get_characteristic(sensor_uuid) is not None:
+                    if self._has_sensor_characteristic(sensor_uuid):
                         _LOGGER.debug("Connected to %s", self._mac)
-                        return True
-
-                    # Stale/incomplete GATT cache: clear and retry once without cache.
-                    if use_cache:
+                        success = True
+                    elif use_cache:
                         _LOGGER.debug(
                             "SENSOR_DATA missing after cached connect for %s; "
                             "retrying without cache",
                             self._mac,
                         )
                         try:
-                            await self._client.clear_cache()
+                            if self._client is not None:
+                                await self._client.clear_cache()
                         except Exception:
                             pass
-                        try:
-                            await self._client.disconnect()
-                        except Exception:
-                            pass
-                        self._client = None
-                        continue
-
-                    _LOGGER.warning(
-                        "Connected to %s but SENSOR_DATA not in GATT services",
-                        self._mac,
-                    )
-                    try:
-                        await self._client.disconnect()
-                    except Exception:
-                        pass
-                    self._client = None
-                    return False
-
+                        to_close.append(self._take_client())
+                        retry_uncached = True
+                    else:
+                        _LOGGER.warning(
+                            "Connected to %s but SENSOR_DATA not in GATT services",
+                            self._mac,
+                        )
+                        to_close.append(self._take_client())
                 except Exception as err:
                     _LOGGER.warning("Failed to connect %s: %s", self._mac, err)
-                    if self._client is not None:
-                        try:
-                            await self._client.disconnect()
-                        except Exception:
-                            pass
-                        self._client = None
-                    return False
+                    to_close.append(self._take_client())
 
-            return False
+            for client in to_close:
+                await self._disconnect_client(client)
+            if success:
+                # Re-check after releasing the lock: a concurrent disconnect() may have
+                # cleared the slot between establish success and our return.
+                if self.isConnected() and self._has_sensor_characteristic(sensor_uuid):
+                    return True
+                _LOGGER.debug(
+                    "Connection to %s was dropped before connect() returned",
+                    self._mac,
+                )
+                return False
+            if not retry_uncached:
+                return False
+
+        return False
 
     async def disconnect(self) -> None:
-        if self._client:
-            try:
-                await self._client.disconnect()
-            except Exception as e:
-                _LOGGER.warning("Error disconnecting %s: %s", self._mac, e)
-            finally:
-                self._client = None
+        async with self._connect_lock:
+            client = self._take_client()
+        # Release lock before awaiting Bleak so connect is not blocked on HCI teardown.
+        await self._disconnect_client(client)
 
     async def _with_disconnect_on_error(self, coro):
         try:
@@ -200,30 +226,31 @@ class BaseDevice:
         BleakGATTServiceCollection even when BlueZ exposes it, which produced
         "Characteristic 00002a00 was not found!" after a successful connect (#101).
 
-        Serialize with connect() via _connect_lock so validate/disconnect cannot race
-        a cache-retry reconnect. Does not perform GATT ReadValue - dead ACL links are
-        caught by the next sensor read via _with_disconnect_on_error.
+        Slot clear is serialized with connect() via _connect_lock; Bleak disconnect
+        runs after the lock is released so a slow HCI teardown cannot block reconnect.
+        Dead ACL links are caught by the next sensor read via _with_disconnect_on_error.
         """
         async with self._connect_lock:
             if not self.isConnected():
-                if self._client is not None:
-                    await self.disconnect()
-                return False
-
-            sensor_uuid = self.chars[CHARACTERISTIC_SENSOR_DATA]
-            try:
-                if self._client.services.get_characteristic(sensor_uuid) is not None:
-                    return True
-            except Exception as err:
+                client = self._take_client() if self._client is not None else None
+                ok = False
+            else:
+                sensor_uuid = self.chars[CHARACTERISTIC_SENSOR_DATA]
+                try:
+                    if self._client.services.get_characteristic(sensor_uuid) is not None:
+                        return True
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Connection validation failed for %s: %s", self._mac, err
+                    )
                 _LOGGER.debug(
-                    "Connection validation failed for %s: %s", self._mac, err
+                    "Connection validation missing SENSOR_DATA for %s", self._mac
                 )
+                client = self._take_client()
+                ok = False
 
-            _LOGGER.debug(
-                "Connection validation missing SENSOR_DATA for %s", self._mac
-            )
-            await self.disconnect()
-            return False
+        await self._disconnect_client(client)
+        return ok
 
     def _bToStr(self, val) -> str:
         return binascii.b2a_hex(val).decode("utf-8")

--- a/custom_components/pax_ble/devices/base_device.py
+++ b/custom_components/pax_ble/devices/base_device.py
@@ -137,8 +137,9 @@ class BaseDevice:
             return True
         except Exception as e:
             _LOGGER.debug("Connection validation failed for %s: %s", self._mac, e)
-            # Mark as disconnected so next operation will reconnect
-            self._client = None
+            # Tear down the ACL link - only nulling _client leaves a BlueZ/hci0 zombie
+            # that can block proxies (see https://github.com/eriknn/ha-pax_ble/issues/101).
+            await self.disconnect()
             return False
 
     def _bToStr(self, val) -> str:

--- a/custom_components/pax_ble/devices/base_device.py
+++ b/custom_components/pax_ble/devices/base_device.py
@@ -69,39 +69,106 @@ class BaseDevice:
         await self.setAuth(self._pin)
 
 
-    async def connect(self, timeout: int = 45) -> bool:
+    async def connect(
+        self, timeout: int = 45, *, use_services_cache: bool = True
+    ) -> bool:
         """Establish a reliable connection using bleak-retry-connector."""
+        sensor_uuid = self.chars[CHARACTERISTIC_SENSOR_DATA]
+        cache_attempts = (True, False) if use_services_cache else (False,)
+
         async with self._connect_lock:
-            # Already connected (or another caller just connected while we waited)?
             if self._client and self._client.is_connected:
-                return True
-
-            try:
-                device = bluetooth.async_ble_device_from_address(self._hass, self._mac.upper())
-                if not device:
-                    raise BleakError(f"Device {self._mac} not found")
-
+                # Already connected still needs a usable GATT map for polling.
+                if self._client.services.get_characteristic(sensor_uuid) is not None:
+                    return True
+                _LOGGER.debug(
+                    "Already connected to %s but SENSOR_DATA missing; reconnecting",
+                    self._mac,
+                )
                 try:
-                    await close_stale_connections()
+                    await self._client.clear_cache()
                 except Exception:
                     pass
-
-                self._client = await establish_connection(
-                    BleakClientWithServiceCache,
-                    device,
-                    name=getattr(self, "name", self._mac),
-                    disconnected_callback=self._handle_disconnect,
-                    use_services_cache=True,
-                    max_attempts=5,
-                    retry_interval=1.0,
-                    timeout=timeout,
-                )
-                _LOGGER.debug("Connected to %s", self._mac)
-                return True
-            except Exception as err:
-                _LOGGER.warning("Failed to connect %s: %s", self._mac, err)
+                try:
+                    await self._client.disconnect()
+                except Exception:
+                    pass
                 self._client = None
-                return False
+            elif self._client is not None:
+                try:
+                    await self._client.disconnect()
+                except Exception:
+                    pass
+                self._client = None
+
+            for use_cache in cache_attempts:
+                try:
+                    device = bluetooth.async_ble_device_from_address(
+                        self._hass, self._mac.upper()
+                    )
+                    if not device:
+                        raise BleakError(f"Device {self._mac} not found")
+
+                    try:
+                        await close_stale_connections()
+                    except Exception:
+                        pass
+
+                    self._client = await establish_connection(
+                        BleakClientWithServiceCache,
+                        device,
+                        name=getattr(self, "name", self._mac),
+                        disconnected_callback=self._handle_disconnect,
+                        use_services_cache=use_cache,
+                        max_attempts=5,
+                        retry_interval=1.0,
+                        timeout=timeout,
+                    )
+
+                    if self._client.services.get_characteristic(sensor_uuid) is not None:
+                        _LOGGER.debug("Connected to %s", self._mac)
+                        return True
+
+                    # Stale/incomplete GATT cache: clear and retry once without cache.
+                    if use_cache:
+                        _LOGGER.debug(
+                            "SENSOR_DATA missing after cached connect for %s; "
+                            "retrying without cache",
+                            self._mac,
+                        )
+                        try:
+                            await self._client.clear_cache()
+                        except Exception:
+                            pass
+                        try:
+                            await self._client.disconnect()
+                        except Exception:
+                            pass
+                        self._client = None
+                        continue
+
+                    _LOGGER.warning(
+                        "Connected to %s but SENSOR_DATA not in GATT services",
+                        self._mac,
+                    )
+                    try:
+                        await self._client.disconnect()
+                    except Exception:
+                        pass
+                    self._client = None
+                    return False
+
+                except Exception as err:
+                    _LOGGER.warning("Failed to connect %s: %s", self._mac, err)
+                    if self._client is not None:
+                        try:
+                            await self._client.disconnect()
+                        except Exception:
+                            pass
+                        self._client = None
+                    return False
+
+            return False
 
     async def disconnect(self) -> None:
         if self._client:
@@ -127,18 +194,34 @@ class BaseDevice:
         return self._client is not None and self._client.is_connected
 
     async def validate_connection(self) -> bool:
-        """Validate that the connection is still working by reading a basic characteristic."""
-        if not self.isConnected():
-            return False
+        """Validate the link without an extra GATT read.
 
-        try:
-            # Try to read device name as a connection health check
-            await asyncio.wait_for(self._client.read_gatt_char(self.chars[CHARACTERISTIC_DEVICE_NAME]), timeout=5.0)
-            return True
-        except Exception as e:
-            _LOGGER.debug("Connection validation failed for %s: %s", self._mac, e)
-            # Tear down the ACL link - only nulling _client leaves a BlueZ/hci0 zombie
-            # that can block proxies (see https://github.com/eriknn/ha-pax_ble/issues/101).
+        GAP Device Name (00002a00) is a poor health check: Bleak often omits it from
+        BleakGATTServiceCollection even when BlueZ exposes it, which produced
+        "Characteristic 00002a00 was not found!" after a successful connect (#101).
+
+        Serialize with connect() via _connect_lock so validate/disconnect cannot race
+        a cache-retry reconnect. Does not perform GATT ReadValue - dead ACL links are
+        caught by the next sensor read via _with_disconnect_on_error.
+        """
+        async with self._connect_lock:
+            if not self.isConnected():
+                if self._client is not None:
+                    await self.disconnect()
+                return False
+
+            sensor_uuid = self.chars[CHARACTERISTIC_SENSOR_DATA]
+            try:
+                if self._client.services.get_characteristic(sensor_uuid) is not None:
+                    return True
+            except Exception as err:
+                _LOGGER.debug(
+                    "Connection validation failed for %s: %s", self._mac, err
+                )
+
+            _LOGGER.debug(
+                "Connection validation missing SENSOR_DATA for %s", self._mac
+            )
             await self.disconnect()
             return False
 

--- a/tests/test_validate_connection_disconnect.py
+++ b/tests/test_validate_connection_disconnect.py
@@ -1,4 +1,4 @@
-"""Regression test for issue #101: validation failure must disconnect.
+"""Regression tests for connection validation (#101 / PR #111).
 
 Run: python3 tests/test_validate_connection_disconnect.py
 """
@@ -11,7 +11,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -39,7 +39,13 @@ sys.modules["bleak_retry_connector"] = brc
 
 bleak = types.ModuleType("bleak")
 bleak_exc = types.ModuleType("bleak.exc")
-bleak_exc.BleakError = Exception
+
+
+class BleakError(Exception):
+    pass
+
+
+bleak_exc.BleakError = BleakError
 sys.modules["bleak"] = bleak
 sys.modules["bleak.exc"] = bleak_exc
 
@@ -69,7 +75,8 @@ _load("custom_components.pax_ble.devices.characteristics", "devices/characterist
 base_device = _load(
     "custom_components.pax_ble.devices.base_device", "devices/base_device.py"
 )
-CHARACTERISTIC_DEVICE_NAME = base_device.CHARACTERISTIC_DEVICE_NAME
+CHARACTERISTIC_SENSOR_DATA = base_device.CHARACTERISTIC_SENSOR_DATA
+SENSOR_UUID = "528b80e8-c47a-4c0a-bdf1-916a7748f412"
 BaseDevice = base_device.BaseDevice
 
 
@@ -82,18 +89,40 @@ class FakeDevice(BaseDevice):
         self._pin = None
         self._connect_lock = asyncio.Lock()
         self._disconnect_callback = None
-        self.chars = {CHARACTERISTIC_DEVICE_NAME: CHARACTERISTIC_DEVICE_NAME}
+        self.chars = {CHARACTERISTIC_SENSOR_DATA: SENSOR_UUID}
         self._client = None
 
 
-class ValidateConnectionDisconnectTests(unittest.IsolatedAsyncioTestCase):
-    async def test_validation_failure_calls_disconnect(self):
+def _services_with_sensor(include: bool = True):
+    services = MagicMock()
+    services.get_characteristic = MagicMock(
+        return_value=MagicMock() if include else None
+    )
+    return services
+
+
+class ValidateConnectionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_validate_success_checks_services_not_gatt_read(self):
         device = FakeDevice()
         client = MagicMock()
         client.is_connected = True
-        client.read_gatt_char = AsyncMock(
-            side_effect=Exception("Characteristic not found")
-        )
+        client.services = _services_with_sensor(True)
+        client.read_gatt_char = AsyncMock()
+        client.disconnect = AsyncMock()
+        device._client = client
+
+        ok = await device.validate_connection()
+
+        self.assertTrue(ok)
+        client.services.get_characteristic.assert_called_once_with(SENSOR_UUID)
+        client.read_gatt_char.assert_not_awaited()
+        client.disconnect.assert_not_awaited()
+
+    async def test_validate_missing_sensor_disconnects(self):
+        device = FakeDevice()
+        client = MagicMock()
+        client.is_connected = True
+        client.services = _services_with_sensor(False)
         client.disconnect = AsyncMock()
         device._client = client
 
@@ -103,19 +132,124 @@ class ValidateConnectionDisconnectTests(unittest.IsolatedAsyncioTestCase):
         client.disconnect.assert_awaited_once()
         self.assertIsNone(device._client)
 
-    async def test_validation_success_keeps_client(self):
+    async def test_validate_stale_not_connected_disconnects(self):
         device = FakeDevice()
         client = MagicMock()
-        client.is_connected = True
-        client.read_gatt_char = AsyncMock(return_value=b"Vent-Axia Svara")
+        client.is_connected = False
         client.disconnect = AsyncMock()
         device._client = client
 
         ok = await device.validate_connection()
 
+        self.assertFalse(ok)
+        client.disconnect.assert_awaited_once()
+        self.assertIsNone(device._client)
+
+    async def test_connect_cache_retry_under_lock(self):
+        device = FakeDevice()
+        stale = MagicMock()
+        stale.is_connected = True
+        stale.services = _services_with_sensor(False)
+        stale.clear_cache = AsyncMock()
+        stale.disconnect = AsyncMock()
+
+        fresh = MagicMock()
+        fresh.is_connected = True
+        fresh.services = _services_with_sensor(True)
+        fresh.disconnect = AsyncMock()
+
+        calls = []
+
+        async def fake_establish(*args, **kwargs):
+            calls.append(kwargs["use_services_cache"])
+            return stale if len(calls) == 1 else fresh
+
+        with patch.object(
+            base_device.bluetooth,
+            "async_ble_device_from_address",
+            return_value=MagicMock(),
+        ), patch.object(
+            base_device, "close_stale_connections", new=AsyncMock()
+        ), patch.object(
+            base_device, "establish_connection", side_effect=fake_establish
+        ):
+            ok = await device.connect()
+
         self.assertTrue(ok)
-        client.disconnect.assert_not_awaited()
+        self.assertEqual(calls, [True, False])
+        stale.clear_cache.assert_awaited_once()
+        stale.disconnect.assert_awaited_once()
+        self.assertIs(device._client, fresh)
+
+    async def test_connect_no_cache_retry_when_uncached_still_missing(self):
+        device = FakeDevice()
+        client = MagicMock()
+        client.is_connected = True
+        client.services = _services_with_sensor(False)
+        client.clear_cache = AsyncMock()
+        client.disconnect = AsyncMock()
+
+        with patch.object(
+            base_device.bluetooth,
+            "async_ble_device_from_address",
+            return_value=MagicMock(),
+        ), patch.object(
+            base_device, "close_stale_connections", new=AsyncMock()
+        ), patch.object(
+            base_device, "establish_connection", new=AsyncMock(return_value=client)
+        ):
+            ok = await device.connect(use_services_cache=False)
+
+        self.assertFalse(ok)
+        client.clear_cache.assert_not_awaited()
+        client.disconnect.assert_awaited()
+        self.assertIsNone(device._client)
+
+    async def test_connect_early_return_when_already_connected_with_sensor(self):
+        device = FakeDevice()
+        client = MagicMock()
+        client.is_connected = True
+        client.services = _services_with_sensor(True)
+        device._client = client
+
+        with patch.object(
+            base_device, "establish_connection", new=AsyncMock()
+        ) as establish:
+            ok = await device.connect()
+
+        self.assertTrue(ok)
+        establish.assert_not_awaited()
         self.assertIs(device._client, client)
+
+    async def test_connect_reconnects_when_already_connected_missing_sensor(self):
+        device = FakeDevice()
+        stale = MagicMock()
+        stale.is_connected = True
+        stale.services = _services_with_sensor(False)
+        stale.clear_cache = AsyncMock()
+        stale.disconnect = AsyncMock()
+        device._client = stale
+
+        fresh = MagicMock()
+        fresh.is_connected = True
+        fresh.services = _services_with_sensor(True)
+        fresh.disconnect = AsyncMock()
+
+        with patch.object(
+            base_device.bluetooth,
+            "async_ble_device_from_address",
+            return_value=MagicMock(),
+        ), patch.object(
+            base_device, "close_stale_connections", new=AsyncMock()
+        ), patch.object(
+            base_device, "establish_connection", new=AsyncMock(return_value=fresh)
+        ):
+            ok = await device.connect()
+
+        self.assertTrue(ok)
+        stale.clear_cache.assert_awaited_once()
+        stale.disconnect.assert_awaited()
+        self.assertIs(device._client, fresh)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_connection_disconnect.py
+++ b/tests/test_validate_connection_disconnect.py
@@ -234,6 +234,76 @@ class ValidateConnectionTests(unittest.IsolatedAsyncioTestCase):
         fresh.is_connected = True
         fresh.services = _services_with_sensor(True)
         fresh.disconnect = AsyncMock()
+        kwargs_seen = []
+
+        async def fake_establish(*args, **kwargs):
+            kwargs_seen.append(kwargs.get("use_services_cache"))
+            return fresh
+
+        with patch.object(
+            base_device.bluetooth,
+            "async_ble_device_from_address",
+            return_value=MagicMock(),
+        ), patch.object(
+            base_device, "close_stale_connections", new=AsyncMock()
+        ), patch.object(
+            base_device, "establish_connection", side_effect=fake_establish
+        ):
+            ok = await device.connect()
+
+        self.assertTrue(ok)
+        stale.clear_cache.assert_awaited_once()
+        stale.disconnect.assert_awaited()
+        self.assertEqual(kwargs_seen, [False])
+        self.assertIs(device._client, fresh)
+
+    async def test_disconnect_clears_slot_before_await(self):
+        device = FakeDevice()
+        cleared = asyncio.Event()
+        old = MagicMock()
+
+        async def slow_disconnect():
+            # Slot must already be empty before Bleak disconnect yields.
+            self.assertIsNone(device._client)
+            cleared.set()
+
+        old.disconnect = slow_disconnect
+        device._client = old
+
+        await device.disconnect()
+
+        self.assertTrue(cleared.is_set())
+        self.assertIsNone(device._client)
+
+    async def test_handle_disconnect_ignores_stale_client(self):
+        device = FakeDevice()
+        old, new = MagicMock(), MagicMock()
+        device._client = new
+        device._handle_disconnect(old)
+        self.assertIs(device._client, new)
+        device._handle_disconnect(new)
+        self.assertIsNone(device._client)
+
+    async def test_validate_disconnect_under_lock_no_deadlock(self):
+        device = FakeDevice()
+        client = MagicMock()
+        client.is_connected = True
+        client.services = _services_with_sensor(False)
+        client.disconnect = AsyncMock()
+        device._client = client
+
+        ok = await asyncio.wait_for(device.validate_connection(), timeout=2)
+
+        self.assertFalse(ok)
+        client.disconnect.assert_awaited()
+        self.assertIsNone(device._client)
+
+    async def test_connect_returns_false_if_slot_cleared_before_return(self):
+        device = FakeDevice()
+        fresh = MagicMock()
+        fresh.is_connected = True
+        fresh.services = _services_with_sensor(True)
+        fresh.disconnect = AsyncMock()
 
         with patch.object(
             base_device.bluetooth,
@@ -243,13 +313,16 @@ class ValidateConnectionTests(unittest.IsolatedAsyncioTestCase):
             base_device, "close_stale_connections", new=AsyncMock()
         ), patch.object(
             base_device, "establish_connection", new=AsyncMock(return_value=fresh)
+        ), patch.object(
+            # connect() only uses the isConnected() method for the post-lock
+            # success re-check; in-lock paths use client.is_connected.
+            device,
+            "isConnected",
+            return_value=False,
         ):
             ok = await device.connect()
 
-        self.assertTrue(ok)
-        stale.clear_cache.assert_awaited_once()
-        stale.disconnect.assert_awaited()
-        self.assertIs(device._client, fresh)
+        self.assertFalse(ok)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_connection_disconnect.py
+++ b/tests/test_validate_connection_disconnect.py
@@ -1,0 +1,122 @@
+"""Regression test for issue #101: validation failure must disconnect.
+
+Run: python3 tests/test_validate_connection_disconnect.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Minimal stubs so base_device imports without Home Assistant installed.
+homeassistant = types.ModuleType("homeassistant")
+homeassistant.__path__ = []
+components = types.ModuleType("homeassistant.components")
+components.__path__ = []
+bluetooth = types.ModuleType("homeassistant.components.bluetooth")
+bluetooth.async_ble_device_from_address = MagicMock()
+sys.modules.update(
+    {
+        "homeassistant": homeassistant,
+        "homeassistant.components": components,
+        "homeassistant.components.bluetooth": bluetooth,
+    }
+)
+
+brc = types.ModuleType("bleak_retry_connector")
+brc.BleakClientWithServiceCache = object
+brc.close_stale_connections = AsyncMock()
+brc.establish_connection = AsyncMock()
+sys.modules["bleak_retry_connector"] = brc
+
+bleak = types.ModuleType("bleak")
+bleak_exc = types.ModuleType("bleak.exc")
+bleak_exc.BleakError = Exception
+sys.modules["bleak"] = bleak
+sys.modules["bleak.exc"] = bleak_exc
+
+# Namespace packages so we can load devices modules without pax_ble/__init__.py.
+for name, path in (
+    ("custom_components", ROOT / "custom_components"),
+    ("custom_components.pax_ble", ROOT / "custom_components/pax_ble"),
+    ("custom_components.pax_ble.devices", ROOT / "custom_components/pax_ble/devices"),
+):
+    mod = types.ModuleType(name)
+    mod.__path__ = [str(path)]
+    sys.modules[name] = mod
+
+
+def _load(name: str, relative: str):
+    spec = importlib.util.spec_from_file_location(
+        name, ROOT / "custom_components/pax_ble" / relative
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_load("custom_components.pax_ble.devices.characteristics", "devices/characteristics.py")
+base_device = _load(
+    "custom_components.pax_ble.devices.base_device", "devices/base_device.py"
+)
+CHARACTERISTIC_DEVICE_NAME = base_device.CHARACTERISTIC_DEVICE_NAME
+BaseDevice = base_device.BaseDevice
+
+
+class FakeDevice(BaseDevice):
+    """Concrete BaseDevice for unit tests."""
+
+    def __init__(self):
+        self._hass = MagicMock()
+        self._mac = "aa:bb:cc:dd:ee:ff"
+        self._pin = None
+        self._connect_lock = asyncio.Lock()
+        self._disconnect_callback = None
+        self.chars = {CHARACTERISTIC_DEVICE_NAME: CHARACTERISTIC_DEVICE_NAME}
+        self._client = None
+
+
+class ValidateConnectionDisconnectTests(unittest.IsolatedAsyncioTestCase):
+    async def test_validation_failure_calls_disconnect(self):
+        device = FakeDevice()
+        client = MagicMock()
+        client.is_connected = True
+        client.read_gatt_char = AsyncMock(
+            side_effect=Exception("Characteristic not found")
+        )
+        client.disconnect = AsyncMock()
+        device._client = client
+
+        ok = await device.validate_connection()
+
+        self.assertFalse(ok)
+        client.disconnect.assert_awaited_once()
+        self.assertIsNone(device._client)
+
+    async def test_validation_success_keeps_client(self):
+        device = FakeDevice()
+        client = MagicMock()
+        client.is_connected = True
+        client.read_gatt_char = AsyncMock(return_value=b"Vent-Axia Svara")
+        client.disconnect = AsyncMock()
+        device._client = client
+
+        ok = await device.validate_connection()
+
+        self.assertTrue(ok)
+        client.disconnect.assert_not_awaited()
+        self.assertIs(device._client, client)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Disconnect (do not only null `_client`) when connection validation fails, so BlueZ/hci0 does not keep a zombie ACL that blocks ESPHome proxies (#101).
- Stop validating with GAP Device Name (`00002a00`). Bleak often omits that characteristic from `BleakGATTServiceCollection` even when BlueZ exposes it, which produced `Characteristic 00002a00 was not found!` after connect succeeded.
- Validate with a **services membership check** for Pax `SENSOR_DATA` (`528b80e8-...`) - no extra GATT read on every poll.
- If a cached connect is missing `SENSOR_DATA`, `clear_cache` and retry once under `_connect_lock` with `use_services_cache=False`.
- Serialize validate with connect via `_connect_lock`; reconnect when already connected but SENSOR_DATA is missing.

## Test plan
- [x] `python3 tests/test_validate_connection_disconnect.py -v` (7 cases)
- [x] Dual-adapter HA (Intel AX200 + ESPHome AtomS3, two Vent-Axia Svara): post-reload RPM refreshes; ages stayed under dual-freeze criteria; boost cycles completed
- [x] Adversarial review: prior radio-load / race / incomplete cache-retry nits addressed; final pass approve-with-nits (no criticals)
- [ ] Maintainer: reproduce #101 hci0 hang before/after on dual-adapter setup