### PR TITLE
Re-arm the refresh timer when entering fast poll mode

### DIFF
--- a/custom_components/pax_ble/coordinator.py
+++ b/custom_components/pax_ble/coordinator.py
@@ -97,6 +97,12 @@ class BaseCoordinator(DataUpdateCoordinator, ABC):
         self._fast_poll_count = 0
         self.update_interval = dt.timedelta(seconds=self._fast_poll_interval)
 
+        # Assigning update_interval only stores the value - the coordinator's
+        # setter does not re-arm the already-scheduled refresh, so the next poll
+        # still lands at the old interval (up to scan_interval away) and values
+        # just written to the device keep reading stale.
+        self._schedule_refresh()
+
     def setNormalPollMode(self):
         _LOGGER.debug("Enabling normal poll mode")
         self._fast_poll_enabled = False


### PR DESCRIPTION
setFastPollMode() sets self.update_interval to the fast interval, but
DataUpdateCoordinator's update_interval setter is a plain assignment: it
stores the value and does not re-arm the refresh that is already scheduled.
The pending poll therefore still fires at the old interval, and only the
poll after that one runs at the fast interval.

In practice that means values written to the device keep reading stale for
up to scan_interval (300s by default). Measured with two writes 60s apart:
neither produced a poll until 300s after the preceding one, rather than
scan_interval_fast after the write. The user-visible symptom is turning
boost on and watching rpm sit at 0.

Calling _schedule_refresh() cancels the stale callback and re-schedules at
the interval just set, so the first fast poll arrives one fast interval
after the write.

Note this deliberately does not use async_request_refresh(). That polls
immediately (its debouncer is immediate=True), which reads the device
before it has applied the write; the stale result is then pushed over the
optimistic entity state and the control visibly snaps back before
correcting itself on the following poll. The defect here is only that
changing the interval does not re-arm the timer, so re-arming the timer is
the whole fix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
