### PR TITLE
Fix edit-device options flow silently saving nothing

### DIFF
--- a/custom_components/pax_ble/config_flow.py
+++ b/custom_components/pax_ble/config_flow.py
@@ -424,8 +424,17 @@ class PaxOptionsFlowHandler(OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            # Update device in config entry
-            new_data = self.config_entry.data.copy()
+            # Update device in config entry.
+            #
+            # .copy() is shallow, so new_data[CONF_DEVICES] would be the same
+            # dict object as config_entry.data[CONF_DEVICES]; updating it in
+            # place mutates the live entry, async_update_entry() then compares
+            # the entry against itself, finds no change, and skips both the
+            # save and the update listener that reloads the entry.
+            new_data = dict(self.config_entry.data)
+            new_data[CONF_DEVICES] = {
+                mac: dict(cfg) for mac, cfg in new_data[CONF_DEVICES].items()
+            }
             new_data[CONF_DEVICES][self.selected_device].update(user_input)
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=new_data


### PR DESCRIPTION
async_step_edit_device copies config_entry.data with .copy(), which is
shallow, so new_data[CONF_DEVICES] is the same dict object as
config_entry.data[CONF_DEVICES]. Calling .update() on the device inside it
mutates the live entry, so by the time async_update_entry() compares
entry.data against the "new" data they are equal. It returns False and
skips the save.

The flow still aborts with edit_success, so it reports success and
persists nothing. The practical effect is that scan_interval,
scan_interval_fast and pin cannot be changed through the UI at all.

Copying the devices level as well makes the change visible to
async_update_entry. That also restores the reload, because the update
listener registered in async_setup_entry only fires when the entry
actually changes - so no explicit async_reload is needed here.

The add and remove paths hit the same shallow-copy problem and work
around it with an explicit _async_schedule_save(); the edit path is the
only one without that workaround, which is why it is the one that fails
visibly. Fixing the copy is the root cause for all three.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
