### PR TITLE
Publish new value before the device write, not after

### DIFF
--- a/custom_components/pax_ble/coordinator.py
+++ b/custom_components/pax_ble/coordinator.py
@@ -285,6 +285,11 @@ class BaseCoordinator(DataUpdateCoordinator, ABC):
         _LOGGER.debug("Set_Data: %s %s", key, value)
         self._state[key] = value
 
+        # Publish straight away. Callers set the value here and only tell Home
+        # Assistant after the device write returns, which leaves the state
+        # machine reporting the old value for the whole duration of that write.
+        self.async_update_listeners()
+
     async def read_deviceinfo(self, disconnect=False) -> bool:
         _LOGGER.debug("Reading device information")
         try:


### PR DESCRIPTION
Every write path (switch.writeVal, number.async_set_native_value,
select.async_select_option, time.async_set_value) does the same thing:
set_data() the new value, await write_data() to push it over Bluetooth,
and only then tell Home Assistant.

set_data() updates the coordinator's _state but publishes nothing, so for
the whole duration of the BLE write the state machine still reports the
old value. Measured across several presses, that window was 0.37-0.76s.
The frontend's toggle flips optimistically on click, gets no confirmation
from the state machine within that window, falls back to the old value,
and then jumps to the new one when the write returns - so the control
visibly snaps back and forth on roughly two presses in three.

Publishing in set_data() fixes switch, number, select and time in one
place. The restore path in PaxCalimaRestoreNumberEntity is safe: it awaits
super().async_added_to_hass() before calling set_data, so the entity is
added and its listener registered by the time this fires.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
