### PR TITLE
Report unknown, not 0%, when humidity cannot be decoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A valid PIN code is required to be able to control the fan. You can add the fan 
 ## Sensor data
 
 The sensors for temp/humidity/light seem to be a bit inaccurate, or I'm not converting them correctly, so don't expect them to be as accurate as from other dedicated sensors.
-The humidity sensor will show 0 when humidity is low!
+The humidity sensor will show `unknown` when the reading is too low to convert - roughly below normal indoor humidity. (Previously this displayed as a misleading 0.)
 Airflow is just a conversion of the fan speed based on a linear correlation between those two. This is a bit inaccurate at best, as the true flow will vary greatly depending on how your fan is mounted.
 
 ## Good to know

--- a/custom_components/pax_ble/devices/calima.py
+++ b/custom_components/pax_ble/devices/calima.py
@@ -74,7 +74,9 @@ class Calima(BaseDevice):
             trigger = "Humidity ventilation"
 
         return FanState(
-            round(math.log2(v[0] - 30) * 10, 2) if v[0] > 30 else 0,
+            # See the note in svensa.py: None (-> "unknown") rather than 0,
+            # so an unconvertible raw value is not reported as a measured 0%.
+            round(math.log2(v[0] - 30) * 10, 2) if v[0] > 30 else None,
             v[1] / 4 - 2.6,
             v[2],
             v[3],

--- a/custom_components/pax_ble/devices/svensa.py
+++ b/custom_components/pax_ble/devices/svensa.py
@@ -109,7 +109,12 @@ class Svensa(BaseDevice):
 
         # FanState = namedtuple("FanState", "Humidity AirQuality Temp Light RPM Mode")
         return FanState(
-            round(15 * math.log2(v[2]) - 75, 2) if v[2] > 35 else 0,
+            # Below the threshold the raw value cannot be converted at all
+            # (log2 of <= 0 is a domain error, and low values give negative
+            # percentages), so there is no reading to report. Return None,
+            # which Home Assistant renders as "unknown", rather than 0 -
+            # which presents "no reading" as a measured 0% RH.
+            round(15 * math.log2(v[2]) - 75, 2) if v[2] > 35 else None,
             v[3],
             v[9],
             v[4],


### PR DESCRIPTION
Both device classes clamp an out-of-range humidity reading to 0:

    svensa: round(15 * math.log2(v[2]) - 75, 2) if v[2] > 35 else 0
    calima: round(math.log2(v[0] - 30) * 10, 2) if v[0] > 30 else 0

The guard itself is necessary - log2 of a non-positive number raises, and
raw values just above zero decode to negative percentages - but 0 is the
wrong thing to substitute. It presents "no valid reading" as a measured
0% relative humidity, which is not a plausible indoor value and is
indistinguishable from a working sensor in a perfectly dry room.

This is not theoretical. On PureAir Sense hardware revision 02.00 the raw
value sits below the threshold at normal room humidity, so the humidity
sensor reports a confident 0% permanently. Measured across six such fans
against reference hygrometers in the same rooms: rooms at 38-40% RH, fans
reporting 0%. The same fans decode correctly once humidity rises - during
a shower one read raw 2512 = 94.4% (Svensa formula, `15*log2(raw)-75`),
against 93.5% on a reference sensor in the same room, using the
existing formula unchanged; the later peak was raw 3300 (~100%).
(The example is from a Svensa - the Calima formula differs.) So the decode is
right and the sensor works; only the resting case is misreported.

Returning None instead makes Home Assistant show the sensor as unknown,
which is what "we cannot read this" should look like. A user then sees
that there is no reading, rather than a wrong one - and anything built on
the value (automations, statistics, graphs) can tell the two apart, which
it cannot when the value is 0.

No change to the decode, the threshold, or any working reading.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Note: this is a presentation fix only - it does not restore a usable ambient
RH reading on hardware that reports below-threshold raw values at rest.
