### PR TITLE
Re-arm the refresh timer when leaving fast poll mode

### DIFF
--- a/custom_components/pax_ble/coordinator.py
+++ b/custom_components/pax_ble/coordinator.py
@@ -112,6 +112,11 @@ class BaseCoordinator(DataUpdateCoordinator, ABC):
             interval = min(self._normal_poll_interval * (2 ** self._connection_failures), self._max_backoff)
         self.update_interval = dt.timedelta(seconds=interval)
 
+        # Same re-arm as setFastPollMode(): assigning update_interval only
+        # stores the value, so the pending tick would still fire once at
+        # the old (fast) interval before the normal interval takes effect.
+        self._schedule_refresh()
+
     async def disconnect(self):
         """Safely disconnect from device."""
         # Cancel any pending reconnection task


### PR DESCRIPTION
Follow-up promised in the #112 review. `setNormalPollMode()` assigns `update_interval` the same way `setFastPollMode()` did before #112, with the same behaviour: the assignment only stores the value, so the already-scheduled tick still fires once at the old (fast) interval before the new interval takes hold.

The direction is benign here - leaving fast mode errs *fast*, costing one extra poll rather than a stale reading - but the pair should behave consistently. Same one-line fix as #112.
