### PR TITLE
Use the same devices-level copy in the add and remove flows

### DIFF
--- a/custom_components/pax_ble/config_flow.py
+++ b/custom_components/pax_ble/config_flow.py
@@ -183,16 +183,15 @@ class PaxConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                         )
                     else:
                         # Integration found, update with new device
-                        new_data = self.config_entry.data.copy()
+                        new_data = dict(self.config_entry.data)
+                        new_data[CONF_DEVICES] = {
+                            mac: dict(cfg)
+                            for mac, cfg in new_data[CONF_DEVICES].items()
+                        }
                         new_data[CONF_DEVICES][dev_mac] = user_input
 
                         self.hass.config_entries.async_update_entry(
                             self.config_entry, data=new_data
-                        )
-                        self.hass.config_entries._async_schedule_save()
-
-                        await self.hass.config_entries.async_reload(
-                            self.config_entry.entry_id
                         )
 
                         return self.async_abort(
@@ -298,15 +297,15 @@ class PaxOptionsFlowHandler(OptionsFlow):
 
                 if pin_verified:
                     # Add device to config entry
-                    new_data = self.config_entry.data.copy()
+                    new_data = dict(self.config_entry.data)
+                    new_data[CONF_DEVICES] = {
+                        mac: dict(cfg)
+                        for mac, cfg in new_data[CONF_DEVICES].items()
+                    }
                     new_data[CONF_DEVICES][user_input[CONF_MAC]] = user_input
 
                     self.hass.config_entries.async_update_entry(
                         self.config_entry, data=new_data
-                    )
-                    self.hass.config_entries._async_schedule_save()
-                    await self.hass.config_entries.async_reload(
-                        self.config_entry.entry_id
                     )
 
                     return self.async_abort(
@@ -473,7 +472,11 @@ class PaxOptionsFlowHandler(OptionsFlow):
             ]
 
             # Remove device from config entry
-            new_data = self.config_entry.data.copy()
+            new_data = dict(self.config_entry.data)
+            new_data[CONF_DEVICES] = {
+                mac: dict(cfg)
+                for mac, cfg in new_data[CONF_DEVICES].items()
+            }
             new_data[CONF_DEVICES].pop(self.selected_device)
 
             await self.async_remove_device(
@@ -482,7 +485,6 @@ class PaxOptionsFlowHandler(OptionsFlow):
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=new_data
             )
-            self.hass.config_entries._async_schedule_save()
 
             return self.async_abort(
                 reason="remove_success",


### PR DESCRIPTION
Follow-up to #113, as suggested in review. The add and remove paths had the same shallow-copy problem and carried workarounds for it: mutating the shared `CONF_DEVICES` dict meant `async_update_entry()` compared the entry to itself, so the private `_async_schedule_save()` call did the saving and (in the add paths) an explicit `async_reload()` did the reloading, while the entry's update listener never fired at all.

With the devices level copied, `async_update_entry()` sees a real change, persists it, and fires the update listener registered in `async_setup_entry` - which reloads the entry. Both workarounds then come out: the private-API save is redundant, and keeping the explicit reload would reload twice.

All three flows now change the entry the same way as the edit path merged in #113.

One behaviour note on remove: previously the pop mutated the live entry and no update event fired; now the entry updates properly and the listener reloads it, which also tears the removed device's coordinator down - previously that only happened on the next restart.

Honesty note: I have not click-tested add/remove on my own fans (removing one here means a physical re-pair to get it back), but the change is structurally identical to the merged edit-path fix. @aioue if your two-Svara rig is still handy, a quick add/remove pass would be very welcome.
